### PR TITLE
feat/add-storyblok

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,3 +1,7 @@
+require("dotenv").config({
+  path: `.env.${process.env.NODE_ENV}`,
+})
+
 module.exports = {
   siteMetadata: {
     title: "Gatsby Deep Dives with Queen Raae and the Nattermob Pirates",
@@ -19,6 +23,13 @@ module.exports = {
           formats: ["auto", "webp", "avif"],
           placeholder: "blurred",
         },
+      },
+    },
+    {
+      resolve: "gatsby-source-storyblok",
+      options: {
+        accessToken: process.env.STORYBLOK_PREVIEW_API_KEY,
+        version: "draft",
       },
     },
   ],

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "gatsby-plugin-react-helmet": "5.0.0",
     "gatsby-plugin-sharp": "4.0.0",
     "gatsby-source-filesystem": "4.0.0",
+    "gatsby-source-storyblok": "^3.0.1",
     "gatsby-transformer-remark": "5.1.0",
     "gatsby-transformer-sharp": "^4.0.0",
     "googleapis": "71.0.0",

--- a/src/pages/{storyblokEntry.slug}.js
+++ b/src/pages/{storyblokEntry.slug}.js
@@ -1,0 +1,68 @@
+import React, { Fragment } from "react"
+import { graphql } from "gatsby"
+
+const getBlok = (blok) => {
+  const { component } = blok
+
+  console.log(component)
+  console.log(blok)
+
+  switch (component) {
+    case "teaser":
+      return (
+        <Fragment>
+          <h2>{blok.headline}</h2>
+          <pre>{JSON.stringify(blok, null, 2)}</pre>
+        </Fragment>
+      )
+
+    case "grid":
+      return (
+        <Fragment>
+          {blok.columns.map((column, index) => {
+            return <pre key={index}>{JSON.stringify(column, null, 2)}</pre>
+          })}
+        </Fragment>
+      )
+
+    case "feature":
+      return (
+        <Fragment>
+          <h2>{blok.name}</h2>
+          <pre>{JSON.stringify(blok, null, 2)}</pre>
+        </Fragment>
+      )
+
+    default:
+      return null
+  }
+}
+
+const StoryblokPage = ({ data }) => {
+  const story = data.storyblokEntry
+  const raw = JSON.parse(story.content)
+
+  const { title, body } = JSON.parse(story.content)
+
+  return (
+    <main>
+      <h1>{title}</h1>
+      {body.map((blok, index) => {
+        return <Fragment key={index}>{getBlok(blok)}</Fragment>
+      })}
+    </main>
+  )
+}
+
+export const query = graphql`
+  query ($slug: String!) {
+    storyblokEntry(slug: { eq: $slug }) {
+      id
+      name
+      full_slug
+      content
+    }
+  }
+`
+
+export default StoryblokPage


### PR DESCRIPTION
- add `gatsby-source-storyblok`
- add `{storyblokEntry.slug}.js` to `src/pages`
- add the code snippet to from [gatsby-source-storybook#rendering-storyblok-content](https://github.com/storyblok/gatsby-source-storyblok#rendering-storyblok-content)