### PR TITLE
feat/countdown-timer

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@heroicons/react": "1.0.5",
     "@raae/gatsby-plugin-let-it-snow": "^0.1.0",
     "@tailwindcss/typography": "0.4.1",
+    "date-fns": "^2.26.0",
     "dotenv": "8.2.0",
     "express-jwt": "6.0.0",
     "gatsby": "4.0.0",

--- a/src/components/countdown-timer.js
+++ b/src/components/countdown-timer.js
@@ -1,0 +1,32 @@
+import React, { Fragment, useEffect, useState } from "react"
+import { formatDistanceToNow } from "date-fns"
+
+const CountdownTimer = ({ end }) => {
+  const [remaining, setRemaining] = useState(null)
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setRemaining(
+        formatDistanceToNow(end, { addSuffix: true, includeSeconds: true })
+      )
+    }, 1000)
+    return () => {
+      clearInterval(interval)
+    }
+  }, [])
+
+  return (
+    <div className="bg-red-600 rounded shadow p-4 flex justify-center">
+      {remaining ? (
+        <div className="grid grid-cols-auto-auto gap-1 items-center text-white text-center">
+          <span>{`We'll be live again ${remaining}`}</span>
+          <span role="img" aria-label="Partying Face">
+            🥳
+          </span>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export default CountdownTimer

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,6 +2,8 @@ import React from "react"
 import { useStaticQuery, graphql, Link } from "gatsby"
 import { GatsbyImage, getImage } from "gatsby-plugin-image"
 
+import CountdownTimer from "../components/countdown-timer"
+
 const IndexPage = () => {
   const data = useStaticQuery(graphql`
     {
@@ -56,6 +58,9 @@ const IndexPage = () => {
             </a>
           </p>
         </div>
+
+        <CountdownTimer end={new Date("January 4, 2022")} />
+
         <div className="grid gap-4">
           <h2 className="text-2xl font-bold font-mono">The streams:</h2>
           <ul className="grid gap-6 lg:grid-cols-2">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,7 @@ module.exports = {
       gridTemplateColumns: {
         ["auto-1fr"]: "auto 1fr",
         ["1fr-auto"]: "1fr auto",
+        ["auto-auto"]: "1fr auto",
       },
     },
   },


### PR DESCRIPTION
Here's my first attempt. This would be hard to test if you wanted to test the actual time remaining... but because it uses `date-fns` you probaby wouldn't test the actual output, only that it has all the right styles and probably some text.

There are other ways to create the time difference using date-fns which would mean we could pass in x2 dates E.g

```javascript
<CountdownTimer  start={...} end={...}/>
```

but if you don't care too much about the testing of the actual timer function then what i've done in this PR is probably fine
<img width="1194" alt="Screenshot 2021-11-21 at 19 58 42" src="https://user-images.githubusercontent.com/1465706/142786820-ef7380f6-897f-4c22-bc24-e5b863cdd626.png">


